### PR TITLE
Fixes bug that the current user's avatar can be deleted.

### DIFF
--- a/avatar-manager.php
+++ b/avatar-manager.php
@@ -586,6 +586,7 @@ function avatar_manager_delete_avatar( $user_id ) {
  *
  * @uses get_post() For taking a post ID and returning the database record for
  * that post.
+ * @uses get_user_meta() For retrieving user avatar id for comparison.
  * @uses avatar_manager_delete_avatar() For deleting an avatar image based on
  * attachment ID.
  *
@@ -596,6 +597,13 @@ function avatar_manager_delete_avatar( $user_id ) {
 function avatar_manager_delete_attachment( $attachment_id ) {
 	// Takes a post ID and returns the database record for that post.
 	$attachment = get_post( $attachment_id, ARRAY_A );
+
+    // Check if it is an avatar that we are deleting, if not, exit.
+    $user_id = $attachment['post_author'];
+    $avatar_id = (int) get_user_meta( $user_id, 'avatar_manager_custom_avatar', true );
+    if ($attachment_id !== $avatar_id) {
+        return;
+    }
 
 	// Deletes an avatar image based on user ID.
 	avatar_manager_delete_avatar( $attachment['post_author'] );


### PR DESCRIPTION
Fixes bug that the current user's avatar can be deleted.

If the current user has a custom avatar, and delete any media attachment the
user's custom avatar is deleted too, as the delete attachment action hook
assumes that it is always the avatar that is asked to be deleted.

This updates adds a check so it is actually the avatar that is being asked
to be deleted before continuing running the avatar delete function.

This fix should probably solve the problem posted here:
http://wordpress.org/support/topic/the-avatar-keeps-being-disabled

As well as possible this old issue:
https://github.com/resourcestream/avatar-manager/issues/5
