### PR TITLE
Using escaping functions with translation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ Avatar Manager is brought to you by these fine folks.
 [Lucas Uzan](https://profiles.wordpress.org/wiiz83),
 [Mateus Neves](https://profiles.wordpress.org/mateusneves),
 [Maura Montero D.](https://profiles.wordpress.org/modima65),
+[Mike Selander](https://profiles.wordpress.org/mikeselander),
 [Natalia Zabotina](https://profiles.wordpress.org/nnz),
 [Pieter Goosen](https://profiles.wordpress.org/pietergoosen),
 [Samantha Muthiah](https://profiles.wordpress.org/schm168),
-[Snowboard Mommy](https://profiles.wordpress.org/snowboardmommy),
-[Mike Selander](https://profiles.wordpress.org/mikeselander)
+[Snowboard Mommy](https://profiles.wordpress.org/snowboardmommy)
 
 
 ## Copyright and License

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Avatar Manager is brought to you by these fine folks.
 [Natalia Zabotina](https://profiles.wordpress.org/nnz),
 [Pieter Goosen](https://profiles.wordpress.org/pietergoosen),
 [Samantha Muthiah](https://profiles.wordpress.org/schm168),
-[Snowboard Mommy](https://profiles.wordpress.org/snowboardmommy)
+[Snowboard Mommy](https://profiles.wordpress.org/snowboardmommy),
+[Mike Selander](https://profiles.wordpress.org/mikeselander)
 
 
 ## Copyright and License

--- a/avatar-manager.php
+++ b/avatar-manager.php
@@ -217,6 +217,7 @@ function avatar_manager_default_size_settings_field() {
  * @uses did_action() For retrieving the number of times an action is fired.
  * @uses __() For retrieving the translated string from the translate().
  * @uses esc_attr() For escaping HTML attributes.
+ * @uses esc_html() For escaping HTML output.
  *
  * @since Avatar Manager 1.0.0
  *
@@ -379,7 +380,7 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 							?>
 							<label>
 								<input <?php checked( $custom_avatar_rating, $key, true ); ?> name="avatar_manager_custom_avatar_rating" type="radio" value="<?php echo esc_attr( $key ); ?>">
-								<?php echo $rating; ?>
+								<?php echo esc_html( $rating ); ?>
 							</label>
 							<br>
 							<?php
@@ -1131,6 +1132,8 @@ add_filter( 'avatar_defaults', 'avatar_manager_avatar_defaults', 10, 1 );
  * @uses get_post_meta() For retrieving attachment meta fields.
  * @uses __() For retrieving the translated string from the translate().
  * @uses apply_filters() For calling the functions added to a filter hook.
+ * @uses esc_html__() For returning translated text that has been escaped for
+ * safe use in HTML.
  *
  * @since Avatar Manager 1.2.0
  *
@@ -1144,7 +1147,7 @@ function avatar_manager_display_media_states( $media_states ) {
 	$meta_avatar = get_post_meta( $post->ID, '_avatar_manager_is_custom_avatar', true );
 
 	if ( ! empty( $meta_avatar ) )
-		$media_states[] = __( 'Avatar Image', 'avatar-manager' );
+		$media_states[] = esc_html__( 'Avatar Image', 'avatar-manager' );
 
 	// Calls the functions added to avatar_manager_display_media_states filter
 	// hook.

--- a/avatar-manager.php
+++ b/avatar-manager.php
@@ -142,7 +142,8 @@ function avatar_manager_sanitize_options( $input ) {
  * Prints Avatar Uploads settings field.
  *
  * @uses avatar_manager_get_options() For retrieving plugin options.
- * @uses esc_html_e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying translated text that has been escaped for
+ * safe use in HTML.
  * @uses checked() For comparing two given values.
  *
  * @since Avatar Manager 1.0.0
@@ -169,7 +170,8 @@ function avatar_manager_avatar_uploads_settings_field() {
  * Prints Default Size settings field.
  *
  * @uses avatar_manager_get_options() For retrieving plugin options.
- * @uses esc_html_e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying translated text that has been escaped for
+ * safe use in HTML.
  *
  * @since Avatar Manager 1.0.0
  */
@@ -201,7 +203,8 @@ function avatar_manager_default_size_settings_field() {
  * @uses restore_current_blog() For restoring the current blog.
  * @uses remove_filter() For removing a function attached to a specified action
  * hook.
- * @uses esc_html_e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying translated text that has been escaped for
+ * safe use in HTML.
  * @uses checked() For comparing two given values.
  * @uses get_avatar() For retrieving the avatar for a user.
  * @uses avatar_manager_get_custom_avatar() For retrieving user custom avatar

--- a/avatar-manager.php
+++ b/avatar-manager.php
@@ -142,7 +142,7 @@ function avatar_manager_sanitize_options( $input ) {
  * Prints Avatar Uploads settings field.
  *
  * @uses avatar_manager_get_options() For retrieving plugin options.
- * @uses _e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying the translated string from the translate().
  * @uses checked() For comparing two given values.
  *
  * @since Avatar Manager 1.0.0
@@ -154,12 +154,12 @@ function avatar_manager_avatar_uploads_settings_field() {
 	<fieldset>
 		<legend class="screen-reader-text">
 			<span>
-				<?php _e( 'Avatar Uploads', 'avatar-manager' ); ?>
+				<?php esc_html_e( 'Avatar Uploads', 'avatar-manager' ); ?>
 			</span>
 		</legend><!-- .screen-reader-text -->
 		<label>
 			<input <?php checked( $options['avatar_uploads'], 1, true ); ?> name="avatar_manager[avatar_uploads]" type="checkbox" value="1">
-			<?php _e( 'Anyone can upload', 'avatar-manager' ); ?>
+			<?php esc_html_e( 'Anyone can upload', 'avatar-manager' ); ?>
 		</label>
 	</fieldset>
 	<?php
@@ -169,7 +169,7 @@ function avatar_manager_avatar_uploads_settings_field() {
  * Prints Default Size settings field.
  *
  * @uses avatar_manager_get_options() For retrieving plugin options.
- * @uses _e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying the translated string from the translate().
  *
  * @since Avatar Manager 1.0.0
  */
@@ -180,11 +180,11 @@ function avatar_manager_default_size_settings_field() {
 	<fieldset>
 		<legend class="screen-reader-text">
 			<span>
-				<?php _e( 'Default Size', 'avatar-manager' ); ?>
+				<?php esc_html_e( 'Default Size', 'avatar-manager' ); ?>
 			</span>
 		</legend><!-- .screen-reader-text -->
 		<label>
-			<?php _e( 'Default size of the avatar image', 'avatar-manager' ); ?>
+			<?php esc_html_e( 'Default size of the avatar image', 'avatar-manager' ); ?>
 			<input class="small-text" min="1" name="avatar_manager[default_size]" step="1" type="number" value="<?php echo $options['default_size']; ?>">
 		</label>
 	</fieldset>
@@ -201,7 +201,7 @@ function avatar_manager_default_size_settings_field() {
  * @uses restore_current_blog() For restoring the current blog.
  * @uses remove_filter() For removing a function attached to a specified action
  * hook.
- * @uses _e() For displaying the translated string from the translate().
+ * @uses esc_html_e() For displaying the translated string from the translate().
  * @uses checked() For comparing two given values.
  * @uses get_avatar() For retrieving the avatar for a user.
  * @uses avatar_manager_get_custom_avatar() For retrieving user custom avatar
@@ -258,32 +258,32 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 	}
 	?>
 	<h3>
-		<?php _e( 'Avatar', 'avatar-manager' ); ?>
+		<?php esc_html_e( 'Avatar', 'avatar-manager' ); ?>
 	</h3>
 	<table class="form-table" id="avatar-manager">
 		<tr>
 			<th>
-				<?php _e( 'Display this avatar', 'avatar-manager' ); ?>
+				<?php esc_html_e( 'Display this avatar', 'avatar-manager' ); ?>
 			</th>
 			<td>
 				<fieldset>
 					<legend class="screen-reader-text">
 						<span>
-							<?php _e( 'Display this avatar', 'avatar-manager' ); ?>
+							<?php esc_html_e( 'Display this avatar', 'avatar-manager' ); ?>
 						</span><!-- .screen-reader-text -->
 					</legend>
 					<label>
 						<input <?php checked( $avatar_type, 'gravatar', true ); ?> name="avatar_manager_avatar_type" type="radio" value="gravatar">
 						<?php echo get_avatar( $profileuser->ID, 32, '', false ); ?>
-						<?php _e( 'Gravatar', 'avatar-manager' ); ?>
+						<?php esc_html_e( 'Gravatar', 'avatar-manager' ); ?>
 					</label>
-					<?php _e( '<a href="http://codex.wordpress.org/How_to_Use_Gravatars_in_WordPress" target="_blank">More information</a>', 'avatar-manager' ); ?>
+					<?php esc_html_e( '<a href="http://codex.wordpress.org/How_to_Use_Gravatars_in_WordPress" target="_blank">More information</a>', 'avatar-manager' ); ?>
 					<?php if ( $user_has_custom_avatar ) : ?>
 						<br>
 						<label>
 							<input <?php checked( $avatar_type, 'custom', true ); ?> name="avatar_manager_avatar_type" type="radio" value="custom">
 							<?php echo avatar_manager_get_custom_avatar( $profileuser->ID, 32, '', false ); ?>
-							<?php _e( 'Custom', 'avatar-manager' ); ?>
+							<?php esc_html_e( 'Custom', 'avatar-manager' ); ?>
 						</label>
 						<?php
 						if ( current_user_can( 'upload_files' ) || $options['avatar_uploads'] ) {
@@ -295,7 +295,7 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 							self_admin_url( IS_PROFILE_PAGE ? 'profile.php' : 'user-edit.php' ) );
 							?>
 							<a class="delete" href="<?php echo wp_nonce_url( $href, 'update-user_' . $profileuser->ID ); ?>" onclick="return showNotice.warn();">
-								<?php _e( 'Delete', 'avatar-manager' ); ?>
+								<?php esc_html_e( 'Delete', 'avatar-manager' ); ?>
 							</a><!-- .delete -->
 							<?php
 						}
@@ -307,18 +307,18 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 		<?php if ( current_user_can( 'upload_files' ) || $options['avatar_uploads'] ) : ?>
 			<tr>
 				<th>
-					<?php _e( 'Select Image', 'avatar-manager' ); ?>
+					<?php esc_html_e( 'Select Image', 'avatar-manager' ); ?>
 				</th>
 				<td>
 					<fieldset>
 						<legend class="screen-reader-text">
 							<span>
-								<?php _e( 'Select Image', 'avatar-manager' ); ?>
+								<?php esc_html_e( 'Select Image', 'avatar-manager' ); ?>
 							</span>
 						</legend><!-- .screen-reader-text -->
 						<p>
 							<label class="description" for="avatar-manager-upload">
-								<?php _e( 'Choose an image from your computer:', 'avatar-manager' ); ?>
+								<?php esc_html_e( 'Choose an image from your computer:', 'avatar-manager' ); ?>
 							</label><!-- .description -->
 							<br>
 							<input id="avatar-manager-upload" name="avatar_manager_import" type="file">
@@ -327,7 +327,7 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 						<?php if ( current_user_can( 'upload_files' ) && did_action( 'wp_enqueue_media' ) ) : ?>
 							<p>
 								<label class="description" for="avatar-manager-choose-from-library-link">
-									<?php _e( 'Or choose an image from your media library:', 'avatar-manager' ); ?>
+									<?php esc_html_e( 'Or choose an image from your media library:', 'avatar-manager' ); ?>
 								</label><!-- .description -->
 								<br>
 								<?php
@@ -339,7 +339,7 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 								self_admin_url( IS_PROFILE_PAGE ? 'profile.php' : 'user-edit.php' ) );
 								?>
 								<a class="button" data-choose="<?php esc_attr_e( 'Choose a Custom Avatar', 'avatar-manager' ); ?>" data-update="<?php esc_attr_e( 'Set as avatar', 'avatar-manager' ); ?>" data-update-link="<?php echo wp_nonce_url( $modal_update_href, 'update-user_' . $profileuser->ID ); ?>" id="avatar-manager-choose-from-library-link">
-									<?php _e( 'Choose Image', 'avatar-manager' ); ?>
+									<?php esc_html_e( 'Choose Image', 'avatar-manager' ); ?>
 								</a><!-- #avatar-manager-choose-from-library-link -->
 							</p>
 						<?php endif; ?>
@@ -350,13 +350,13 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 		<?php if ( $user_has_custom_avatar ) : ?>
 			<tr>
 				<th>
-					<?php _e( 'Avatar Rating', 'avatar-manager' ); ?>
+					<?php esc_html_e( 'Avatar Rating', 'avatar-manager' ); ?>
 				</th>
 				<td>
 					<fieldset>
 						<legend class="screen-reader-text">
 							<span>
-								<?php _e( 'Avatar Rating', 'avatar-manager' ); ?>
+								<?php esc_html_e( 'Avatar Rating', 'avatar-manager' ); ?>
 							</span>
 						</legend><!-- .screen-reader-text -->
 						<?php
@@ -386,7 +386,7 @@ function avatar_manager_edit_user_profile( $profileuser ) {
 						}
 						?>
 						<span class="description">
-							<?php _e( 'Choose a rating for your custom avatar.', 'avatar-manager' ); ?>
+							<?php esc_html_e( 'Choose a rating for your custom avatar.', 'avatar-manager' ); ?>
 						</span><!-- .description -->
 					</fieldset>
 				</td>


### PR DESCRIPTION
Moving translations to use the proper escaping functions when the translation is printing to the page.

Resolves #27
